### PR TITLE
Replaces Amber::Router::Params::URL_ENCODED_FORM

### DIFF
--- a/src/amber_spec/controller/test.cr
+++ b/src/amber_spec/controller/test.cr
@@ -1,11 +1,22 @@
 abstract class Spec::ControllerTestCase
-  HTTP_VERBS = %w(get head post put patch delete)
+  MODIFYING_HTTP_VERBS = %w(post put patch)
+  HTTP_VERBS           = %w(get head delete)
 
   macro inherited
+
+	# Content type should be set for request that have body
+	# get requests do not have body so no need to have content type header
+    {% for method in MODIFYING_HTTP_VERBS %}
+    def {{method.id}}(path, headers : HTTP::Headers? = nil, body : String? = nil)
+      request = HTTP::Request.new("{{method.id}}".upcase, path, headers, body )
+      request.headers["Content-Type"] = "application/x-www-form-urlencoded"
+      Request.response = process_request request
+    end
+    {% end %}
+
     {% for method in HTTP_VERBS %}
     def {{method.id}}(path, headers : HTTP::Headers? = nil, body : String? = nil)
       request = HTTP::Request.new("{{method.id}}".upcase, path, headers, body )
-      request.headers["Content-Type"] = Amber::Router::Params::URL_ENCODED_FORM
       Request.response = process_request request
     end
     {% end %}

--- a/src/amber_spec/controller/test.cr
+++ b/src/amber_spec/controller/test.cr
@@ -1,6 +1,6 @@
 abstract class Spec::ControllerTestCase
-  MODIFYING_HTTP_VERBS = %w(post put patch)
-  HTTP_VERBS           = %w(get head delete)
+  MODIFYING_HTTP_VERBS = %w(get head post put patch delete)
+  HTTP_VERBS           = %w(get head)
 
   macro inherited
 
@@ -9,14 +9,9 @@ abstract class Spec::ControllerTestCase
     {% for method in MODIFYING_HTTP_VERBS %}
     def {{method.id}}(path, headers : HTTP::Headers? = nil, body : String? = nil)
       request = HTTP::Request.new("{{method.id}}".upcase, path, headers, body )
-      request.headers["Content-Type"] = "application/x-www-form-urlencoded"
-      Request.response = process_request request
-    end
-    {% end %}
-
-    {% for method in HTTP_VERBS %}
-    def {{method.id}}(path, headers : HTTP::Headers? = nil, body : String? = nil)
-      request = HTTP::Request.new("{{method.id}}".upcase, path, headers, body )
+      unless HTTP_VERBS.includes? method
+        request.headers["Content-Type"] = "application/x-www-form-urlencoded"
+      end
       Request.response = process_request request
     end
     {% end %}


### PR DESCRIPTION
- I removes Amber::Router::Params::URL_ENCODED_FORM and replaces it with
"application/x-www-form-urlencoded"
- Adds content type for request Put Patch Post
- Get Head and Delete do not have content type

Thank you @marksiemers for opening the original PR on this.